### PR TITLE
Fixing floor division bug in  when creating cross-product array holder

### DIFF
--- a/pysal/spreg/diagnostics.py
+++ b/pysal/spreg/diagnostics.py
@@ -969,10 +969,10 @@ def white(reg):
 
     # Compute cross-products and squares of the regression variables
     if type(X).__name__ == 'ndarray':
-        A = np.zeros((n, (k * (k + 1)) / 2))
+        A = np.zeros((n, (k * (k + 1)) // 2))
     elif type(X).__name__ == 'csc_matrix' or type(X).__name__ == 'csr_matrix':
         # this is probably inefficient
-        A = SP.lil_matrix((n, (k * (k + 1)) / 2))
+        A = SP.lil_matrix((n, (k * (k + 1)) // 2))
     else:
         raise Exception, "unknown X type, %s" % type(X).__name__
     counter = 0


### PR DESCRIPTION
This is a small floor division error that occurs in `diagnostics.white` but was being picked up in `ols` and `ols_regimes`. I think this PR fixes all the remaining error in `spreg` related to floor division.